### PR TITLE
UI updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## May 12, 2021
 * Fix bug on VLS testing visual
+* Alter UI to provide a dropdown for output types
+* Update to Datapackr 4.5.1
 
 ## May 11, 2021
 * [DP-247](https://jira.pepfar.net/browse/DP-247) AGYW_PREV was doubling for DREAMS countries who set targets below the PSNU level


### PR DESCRIPTION
Hide the "New PSNUxIM" choice if the tool is an OPU DataPack, or if the DataPack does not need a new PSNUxIM tab. 