### PR TITLE
Patches issue with handling of regional tools in app

### DIFF
--- a/R/sendTimeStampLogToS3.R
+++ b/R/sendTimeStampLogToS3.R
@@ -11,8 +11,8 @@ sendTimeStampLogToS3 <- function(d) {
            ".csv")
 
   timestamp_info <- list(
-    ou = d$info$operating_unit$ou,
-    ou_id = d$info$operating_unit$ou_id,
+    ou = d$info$datapack_name,
+    ou_id = d$info$country_uids,
     country_name = d$info$datapack_name,
     country_uids = paste(d$info$country_uids, sep = "", collapse = ", "),
     upload_timestamp = strftime(as.POSIXlt(Sys.time(), "UTC"), "%Y-%m-%d %H:%M:%S"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -58,21 +58,6 @@ fetchSupportFiles <- function(path) {
   return(file_name2)
 }
 
-getOperatingUnitFromCountryUIDs <- function(country_uids) {
-  ou <- datapackr::valid_PSNUs %>%
-    dplyr::select(ou, ou_id, country_name, country_uid) %>%
-    dplyr::distinct() %>%
-    dplyr::filter(country_uid %in% country_uids) %>%
-    dplyr::select(ou, ou_id) %>%
-    dplyr::distinct()
-
-  if (NROW(ou) != 1) {
-    stop("Datapacks cannot belong to multiple operating units")
-  }
-
-  return(ou)
-}
-
 sendDataPackErrorUI <- function(r) {
   if (!r) {
     showModal(modalDialog(title = "Error",

--- a/R/validateMechanisms.R
+++ b/R/validateMechanisms.R
@@ -5,12 +5,12 @@ validateMechanisms <- function(d, d2_session) {
 
   period_info <- datimvalidation::getPeriodFromISO(paste0(d$info$cop_year, "Oct"))
 
-  operating_unit <- getOperatingUnitFromCountryUIDs(d$info$country_uids)
+  operating_units <- strsplit(d$info$country_uids, split = ",")[[1]]
 
   mechs_datim <- datapackr::getMechanismView(d2_session = d2_session,
                                              update_stale_cache = TRUE,
                                              cached_mechs_path = "data/mechs.rds") %>%
-    dplyr::filter(ou == operating_unit$ou) %>%
+    dplyr::filter(ou %in% operating_units) %>%
     dplyr::filter(!is.na(startdate)) %>%
     dplyr::filter(!is.na(enddate)) %>%
     dplyr::filter(startdate <= period_info$startDate) %>%

--- a/R/validationSummary2.R
+++ b/R/validationSummary2.R
@@ -8,8 +8,8 @@ validationSummary2 <- function(d) {
     `colnames<-`(c("test_name", "validation_issue_category")) # nolint
 
   dplyr::left_join(tests_names, tests_rows, by = "test_name") %>%
-    dplyr::mutate(ou = d$info$operating_unit$ou,
-                  ou_id = d$info$operating_unit$ou_id,
+    dplyr::mutate(ou = d$info$datapack_name,
+                  ou_id = d$info$country_uids,
                   country_name = d$info$datapack_name,
                   country_uid = paste(d$info$country_uids, sep = "", collapse = ", "),
                   ts = strftime(Sys.time(), "%Y-%m-%d %H:%M:%S"),

--- a/server.R
+++ b/server.R
@@ -739,8 +739,6 @@ shinyServer(function(input, output, session) {
         d$info$approval_status <- "UNAPPROVED"
         #Generate a unique identifier
         d$info$uuid <- user_input$uuid
-        #Get a single operating unit from the country IDs
-        d$info$operating_unit <- getOperatingUnitFromCountryUIDs(d$info$country_uids)
         #Log the validation to S3
         sendEventToS3(d, "VALIDATE")
         flog.info(paste0("Initiating validation of ", d$info$datapack_name, " DataPack."), name = "datapack")


### PR DESCRIPTION
Partial fix for DP-502, patches the handling issues within the app but does not patch issues upstream in `datapackr`.
The upstream issue occurs in `checkAnalytics` but everything downstream from there appears to work as expected.
Removes function `getOperatingUnitsFromCountryUIDs`.