### PR TITLE
Revise validation rule output

### DIFF
--- a/server.R
+++ b/server.R
@@ -516,7 +516,10 @@ shinyServer(function(input, output, session) {
       data.frame(message = "Congratulations! No validation rule issues found!")
 
     } else {
-      vr
+      vr %>%
+        dplyr::filter(`Valid` == 'FALSE') %>%
+        dplyr::select(1:6)
+
     }
   })
 


### PR DESCRIPTION
This enhancement slightly changes the output in the validation rule report. All validation rule evaluations will be output, even if there is not a violation of the rule. Only failing rules will be shown in the app user interface however. This enhancement will allow for easier reallocation of data between mechanisms or PSNUs in the PSNUxIM tab