### PR TITLE
[DP-587] moved the formatting function out from writeDataTable

### DIFF
--- a/R/downloadFlatPack.R
+++ b/R/downloadFlatPack.R
@@ -20,10 +20,13 @@ downloadFlatPack <- function(d) {
     )
   }
   if (!is.null(d$data$modality_summary)) {
+    formatMST = formatModalitySummaryTable(d)
+
     openxlsx::addWorksheet(wb, "HTS Summary")
     openxlsx::writeDataTable(
       wb = wb,
-      sheet = "HTS Summary", x = formatModalitySummaryTable(d)
+      sheet = "HTS Summary",
+      x = formatMST
     )
   }
   if (!is.null(d$memo$datapack$by_prio)) {


### PR DESCRIPTION
## Developer: @JordanBalesBAO 



### Summary of Proposed Changes
Bulleted description of what this code changes, adds, removes, or resolves in the package
- Moved formatting function related to HTS Summary Table outside of writexlsx. 
- This enables the columns to round as expected
- Between openxlsx and Shiny's cache the function wasn't actually being completed.


### Related Issues
- DP-587
- etc.

## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
